### PR TITLE
Fixed syntax error (missing parens)

### DIFF
--- a/fitapp/tasks.py
+++ b/fitapp/tasks.py
@@ -94,7 +94,7 @@ def get_time_series_data(fitbit_user, cat, resource, date=None):
                             # bog down the server
                             get_intraday_data.apply_async(
                                 (fbuser.fitbit_user, _type.category,
-                                 _type.resource, tz_offset), {'date': date},
+                                 _type.resource, date, tz_offset),
                                 countdown=(2 * i))
                     # Create new record or update existing record
                     tsd, created = TimeSeriesData.objects.get_or_create(

--- a/fitapp/utils.py
+++ b/fitapp/utils.py
@@ -77,7 +77,7 @@ def get_fitbit_profile(fbuser, key=None):
     :return:
     """
 
-    fb = create_fitbit(**fbuser.get_user_data)
+    fb = create_fitbit(**fbuser.get_user_data())
     data = fb.user_profile_get()
     data = data['user']
     if key:


### PR DESCRIPTION
The celery worker was throwing errors because of these missing parens.